### PR TITLE
Add wizard steps and job info utils

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,32 +1,41 @@
 import streamlit as st
-from agents.file_agent import extract_text_from_pdf
-from functions.field_extraction import extract_job_fields
-from functions.boolean_search import generate_boolean_search
 
-st.set_page_config(page_title="Vacalyser FC2 Demo", layout="wide")
-st.title("📄 Vacalyser – Function Calling Demo (Option 1+2)")
-
-# Mode-Auswahl: Option 1 oder 2
-mode = st.radio(
-    "Extraction Mode",
-    options=["Function Calling (ChatCompletion)", "Responses API (Tool Loop)"],
-    index=0,
-    help="Option 1: Direktes Function Calling / Option 2: Responses API Tool Loop",
+from wizard_steps import (
+    wizard_step_1_basic,
+    wizard_step_2_company,
+    wizard_step_3_department,
+    wizard_step_4_role,
+    wizard_step_5_tasks,
+    wizard_step_6_skills,
+    wizard_step_7_compensation,
+    wizard_step_8_recruitment,
 )
 
-uploaded_file = st.file_uploader("Upload Job Ad (PDF)", type=["pdf"])
-language = st.selectbox("Sprache der Anzeige", ["de", "en"], index=0)
+st.set_page_config(page_title="Vacalyser Wizard", layout="wide")
 
-if uploaded_file:
-    st.subheader("📃 Extracted Text")
-    text = extract_text_from_pdf(uploaded_file)
-    st.text_area("Raw Text", text, height=300)
+if "current_step" not in st.session_state:
+    st.session_state.current_step = 0
+if "job_fields" not in st.session_state:
+    st.session_state.job_fields = {}
 
-    st.subheader("🧠 Structured Job Fields")
-    with st.spinner("Extrahiere strukturierte Daten ..."):
-        extracted = extract_job_fields(text, language, mode)
-    st.json(extracted)
+steps = [
+    wizard_step_1_basic,
+    wizard_step_2_company,
+    wizard_step_3_department,
+    wizard_step_4_role,
+    wizard_step_5_tasks,
+    wizard_step_6_skills,
+    wizard_step_7_compensation,
+    wizard_step_8_recruitment,
+]
 
-    st.subheader("🔍 Boolean Search String")
-    boolean_string = generate_boolean_search(extracted)
-    st.code(boolean_string, language="text")
+steps[st.session_state.current_step]()
+
+col_prev, col_next = st.columns(2)
+with col_prev:
+    if st.button("Zurück", disabled=st.session_state.current_step == 0):
+        st.session_state.current_step = max(0, st.session_state.current_step - 1)
+with col_next:
+    if st.button("Weiter", key="next_btn"):
+        if st.session_state.current_step < len(steps) - 1:
+            st.session_state.current_step += 1

--- a/utils/utils_jobinfo.py
+++ b/utils/utils_jobinfo.py
@@ -1,0 +1,93 @@
+# utils_jobinfo.py
+"""Utility functions for job data extraction and session management."""
+
+from __future__ import annotations
+
+import base64
+import re
+from typing import Dict, Optional
+
+import docx
+import fitz  # PyMuPDF
+import streamlit as st
+
+
+def extract_text_from_pdf(file) -> str:
+    """Return plain text from a PDF file."""
+    doc = fitz.open(stream=file, filetype="pdf")
+    return "".join(page.get_text() for page in doc)
+
+
+def extract_text_from_docx(file) -> str:
+    """Return text from a DOCX file."""
+    doc = docx.Document(file)
+    return "\n".join(para.text for para in doc.paragraphs)
+
+
+def detect_file_type(file) -> Optional[str]:
+    """Detect file type based on extension."""
+    name = file.name.lower()
+    if name.endswith(".pdf"):
+        return "pdf"
+    if name.endswith(".docx"):
+        return "docx"
+    if name.endswith(".txt"):
+        return "txt"
+    return None
+
+
+def extract_text(file) -> str:
+    """Extract content from a supported file."""
+    filetype = detect_file_type(file)
+    if filetype == "pdf":
+        return extract_text_from_pdf(file)
+    if filetype == "docx":
+        return extract_text_from_docx(file)
+    if filetype == "txt":
+        return file.read().decode("utf-8")
+    raise ValueError("Unsupported file type")
+
+
+def basic_field_extraction(text: str) -> Dict[str, str]:
+    """Naive regex extraction of some fields from text."""
+    fields: Dict[str, str] = {}
+    job_title = re.search(r"(?i)(Stellenbezeichnung|Jobtitel|Position):?\s*(.+)", text)
+    if job_title:
+        fields["job_title"] = job_title.group(2).strip()
+    company_name = re.search(r"(?i)(Unternehmen|Company|Firma):?\s*(.+)", text)
+    if company_name:
+        fields["company_name"] = company_name.group(2).strip()
+    return fields
+
+
+def save_fields_to_session(fields: Dict[str, str]) -> None:
+    """Persist fields in Streamlit session state."""
+    st.session_state.setdefault("job_fields", {}).update(fields)
+
+
+def display_fields_editable() -> None:
+    """Show all stored fields as editable inputs."""
+    fields = st.session_state.get("job_fields", {})
+    st.markdown("### Extrahierte Jobdaten / Extracted Job Info")
+    for key, value in fields.items():
+        st.text_input(key.replace("_", " ").title(), value, key=f"edit_{key}")
+
+
+def export_fields_as_markdown() -> None:
+    """Provide a download link for the stored fields as Markdown."""
+    fields = st.session_state.get("job_fields", {})
+    md = "\n".join(f"**{k.replace('_', ' ').capitalize()}:** {v}" for k, v in fields.items())
+    b64 = base64.b64encode(md.encode()).decode()
+    href = (
+        f'<a href="data:text/markdown;base64,{b64}" download="jobinfo.md">'
+        "Markdown herunterladen / Download Markdown</a>"
+    )
+    st.markdown(href, unsafe_allow_html=True)
+
+
+def display_all_fields_multiline_copy() -> None:
+    """Show fields as multiline text areas."""
+    fields = st.session_state.get("job_fields", {})
+    st.markdown("### Alle Felder / All Fields")
+    for key, value in fields.items():
+        st.text_area(key.replace("_", " ").title(), value, key=f"multi_{key}")

--- a/wizard_steps.py
+++ b/wizard_steps.py
@@ -1,0 +1,273 @@
+"""Streamlit wizard steps for job data collection."""
+
+from __future__ import annotations
+
+import requests
+import streamlit as st
+
+from utils.utils_jobinfo import (
+    basic_field_extraction,
+    display_fields_editable,
+    extract_text,
+    save_fields_to_session,
+)
+
+
+def wizard_step_1_basic() -> None:
+    """Step 1: capture basic job data."""
+    st.header("1. Grunddaten / Basic Data")
+    st.subheader(
+        "Das Tool hilft Linemanagern, Informationsverluste im Recruiting zu vermeiden "
+        "und den besten Kandidaten langfristig zu binden."
+    )
+    fields = st.session_state.get("job_fields", {})
+    job_title = st.text_input("Jobtitel / Job Title *", fields.get("job_title", ""))
+    url = st.text_input("Job Ad URL", fields.get("job_url", ""))
+    uploaded = st.file_uploader("Job Ad File", type=["pdf", "docx", "txt"])
+
+    text = ""
+    if uploaded is not None:
+        text = extract_text(uploaded)
+    elif url:
+        try:
+            response = requests.get(url, timeout=10)
+            response.raise_for_status()
+            text = response.text
+        except Exception as exc:  # pragma: no cover - network
+            st.error(f"Fehler beim Laden der URL: {exc}")
+
+    if text:
+        extracted = basic_field_extraction(text)
+        save_fields_to_session(extracted)
+        display_fields_editable()
+
+    if not job_title:
+        st.warning("Bitte Jobtitel eingeben. / Please enter job title.")
+
+    fields["job_title"] = job_title
+    fields["job_url"] = url
+    st.session_state["job_fields"] = fields
+
+
+def wizard_step_2_company() -> None:
+    """Step 2: company information."""
+    fields = st.session_state.get("job_fields", {})
+    st.header(f"2. Unternehmensdaten / Company Info – {fields.get('company_name', '')}")
+    st.subheader(
+        "Transparente Unternehmensinfos erleichtern Kandidaten die Entscheidung."
+    )
+    display_fields_editable()
+    fields["company_name"] = st.text_input(
+        "Unternehmen / Company Name *", fields.get("company_name", "")
+    )
+    fields["city"] = st.text_input("Stadt / City *", fields.get("city", ""))
+    with st.expander("Weitere Angaben / More"):
+        fields["headquarters_location"] = st.text_input(
+            "Hauptsitz / Headquarters Location", fields.get("headquarters_location", "")
+        )
+        fields["company_website"] = st.text_input(
+            "Unternehmenswebsite / Company Website", fields.get("company_website", "")
+        )
+    st.session_state["job_fields"] = fields
+
+
+def wizard_step_3_department() -> None:
+    """Step 3: department and team."""
+    fields = st.session_state.get("job_fields", {})
+    st.header("3. Abteilung & Team / Department and Team Info")
+    display_fields_editable()
+    with st.expander("Team/Abteilung (optional)"):
+        fields["brand_name"] = st.text_input("Markenname / Brand Name", fields.get("brand_name", ""))
+        fields["team_structure"] = st.text_area(
+            "Teamstruktur / Team Structure", fields.get("team_structure", "")
+        )
+    st.session_state["job_fields"] = fields
+
+
+def wizard_step_4_role() -> None:
+    """Step 4: role definition."""
+    fields = st.session_state.get("job_fields", {})
+    st.header("4. Rollen-Definition / Role Definition")
+    display_fields_editable()
+    fields["job_type"] = st.selectbox(
+        "Jobart / Job Type *",
+        ["Vollzeit / Full-Time", "Teilzeit / Part-Time", "Praktikum / Internship", "Freelance"],
+        index=0,
+    )
+    fields["contract_type"] = st.selectbox(
+        "Vertragstyp / Contract Type *",
+        ["Unbefristet / Permanent", "Befristet / Fixed-term", "Werkvertrag / Contract for Work"],
+        index=0,
+    )
+    fields["job_level"] = st.selectbox(
+        "Karrierelevel / Job Level *",
+        ["Junior", "Mid", "Senior", "Lead", "Management"],
+        index=0,
+    )
+    fields["role_description"] = st.text_area(
+        "Rollenbeschreibung / Role Description *", fields.get("role_description", "")
+    )
+    fields["role_type"] = st.text_input("Rollentyp / Role Type *", fields.get("role_type", ""))
+    with st.expander("Weitere Optionen / More Options"):
+        fields["date_of_employment_start"] = st.date_input(
+            "Startdatum / Start Date", fields.get("date_of_employment_start", None)
+        )
+        fields["role_performance_metrics"] = st.text_area(
+            "Leistungskennzahlen / Performance Metrics", fields.get("role_performance_metrics", "")
+        )
+        fields["role_priority_projects"] = st.text_area(
+            "Prioritätsprojekte / Priority Projects", fields.get("role_priority_projects", "")
+        )
+        fields["travel_requirements"] = st.text_input(
+            "Reisebereitschaft / Travel Requirements", fields.get("travel_requirements", "")
+        )
+        fields["work_schedule"] = st.text_input(
+            "Arbeitszeiten / Work Schedule", fields.get("work_schedule", "")
+        )
+        fields["role_keywords"] = st.text_input(
+            "Schlüsselwörter / Role Keywords", fields.get("role_keywords", "")
+        )
+        fields["decision_making_authority"] = st.text_input(
+            "Entscheidungskompetenz / Decision Making Authority", fields.get("decision_making_authority", "")
+        )
+    with st.expander("Fortgeschritten / Advanced", expanded=False):
+        fields["reports_to"] = st.text_input("Berichtet an / Reports To", fields.get("reports_to", ""))
+        fields["supervises"] = st.text_input("Führungsspanne / Supervises", fields.get("supervises", ""))
+    st.session_state["job_fields"] = fields
+
+
+def wizard_step_5_tasks() -> None:
+    """Step 5: tasks and responsibilities."""
+    fields = st.session_state.get("job_fields", {})
+    st.header("5. Aufgaben & Verantwortlichkeiten / Tasks & Responsibilities")
+    display_fields_editable()
+    fields["task_list"] = st.text_area("Aufgabenliste / Task List *", fields.get("task_list", ""))
+    with st.expander("Weitere Aufgaben / More Tasks"):
+        fields["key_responsibilities"] = st.text_area(
+            "Hauptverantwortlichkeiten / Key Responsibilities", fields.get("key_responsibilities", "")
+        )
+        fields["technical_tasks"] = st.text_area(
+            "Technische Aufgaben / Technical Tasks", fields.get("technical_tasks", "")
+        )
+        fields["managerial_tasks"] = st.text_area(
+            "Managementaufgaben / Managerial Tasks", fields.get("managerial_tasks", "")
+        )
+        fields["administrative_tasks"] = st.text_area(
+            "Administrative Aufgaben / Administrative Tasks", fields.get("administrative_tasks", "")
+        )
+        fields["customer_facing_tasks"] = st.text_area(
+            "Kundenkontakt / Customer Facing Tasks", fields.get("customer_facing_tasks", "")
+        )
+        fields["internal_reporting_tasks"] = st.text_area(
+            "Reporting intern / Internal Reporting Tasks", fields.get("internal_reporting_tasks", "")
+        )
+        fields["performance_tasks"] = st.text_area(
+            "Performance-Aufgaben / Performance Tasks", fields.get("performance_tasks", "")
+        )
+        fields["innovation_tasks"] = st.text_area(
+            "Innovationsaufgaben / Innovation Tasks", fields.get("innovation_tasks", "")
+        )
+        fields["task_prioritization"] = st.text_area(
+            "Aufgabenpriorisierung / Task Prioritization", fields.get("task_prioritization", "")
+        )
+    st.session_state["job_fields"] = fields
+
+
+def wizard_step_6_skills() -> None:
+    """Step 6: required skills."""
+    fields = st.session_state.get("job_fields", {})
+    st.header("6. Skills & Kompetenzen / Skills & Competencies")
+    display_fields_editable()
+    fields["must_have_skills"] = st.text_area("Must-have Skills *", fields.get("must_have_skills", ""))
+    with st.expander("Weitere Skills / More Skills"):
+        fields["hard_skills"] = st.text_area("Hard Skills", fields.get("hard_skills", ""))
+        fields["soft_skills"] = st.text_area("Soft Skills", fields.get("soft_skills", ""))
+        fields["nice_to_have_skills"] = st.text_area(
+            "Nice-to-have Skills", fields.get("nice_to_have_skills", "")
+        )
+        fields["certifications_required"] = st.text_area(
+            "Zertifikate / Certifications Required", fields.get("certifications_required", "")
+        )
+        fields["language_requirements"] = st.text_area(
+            "Sprachkenntnisse / Language Requirements", fields.get("language_requirements", "")
+        )
+        fields["tool_proficiency"] = st.text_area("Toolkenntnisse / Tool Proficiency", fields.get("tool_proficiency", ""))
+        fields["technical_stack"] = st.text_area("Technischer Stack / Technical Stack", fields.get("technical_stack", ""))
+        fields["domain_expertise"] = st.text_area("Fachexpertise / Domain Expertise", fields.get("domain_expertise", ""))
+        fields["leadership_competencies"] = st.text_area(
+            "Leadership-Kompetenzen / Leadership Competencies", fields.get("leadership_competencies", "")
+        )
+        fields["industry_experience"] = st.text_area(
+            "Branchenerfahrung / Industry Experience", fields.get("industry_experience", "")
+        )
+        fields["analytical_skills"] = st.text_area(
+            "Analytische Fähigkeiten / Analytical Skills", fields.get("analytical_skills", "")
+        )
+        fields["communication_skills"] = st.text_area(
+            "Kommunikationsfähigkeiten / Communication Skills", fields.get("communication_skills", "")
+        )
+        fields["project_management_skills"] = st.text_area(
+            "Projektmanagement / Project Management Skills", fields.get("project_management_skills", "")
+        )
+        fields["soft_requirement_details"] = st.text_area(
+            "Details zu Soft Requirements", fields.get("soft_requirement_details", "")
+        )
+        fields["visa_sponsorship"] = st.text_input("Visa Sponsorship", fields.get("visa_sponsorship", ""))
+    st.session_state["job_fields"] = fields
+
+
+def wizard_step_7_compensation() -> None:
+    """Step 7: compensation and benefits."""
+    fields = st.session_state.get("job_fields", {})
+    st.header("7. Vergütung & Benefits / Compensation & Benefits")
+    display_fields_editable()
+    fields["salary_range"] = st.text_input("Gehaltsrange / Salary Range *", fields.get("salary_range", ""))
+    fields["currency"] = st.selectbox("Währung / Currency *", ["EUR", "CHF", "GBP", "USD", "other"], index=0)
+    fields["pay_frequency"] = st.selectbox(
+        "Auszahlungsrhythmus / Pay Frequency *",
+        ["Monatlich / Monthly", "Jährlich / Annually", "Wöchentlich / Weekly"],
+        index=0,
+    )
+    with st.expander("Weitere Benefits / More Benefits"):
+        fields["bonus_scheme"] = st.text_area("Bonusregelung / Bonus Scheme", fields.get("bonus_scheme", ""))
+        fields["commission_structure"] = st.text_area(
+            "Provisionsmodell / Commission Structure", fields.get("commission_structure", "")
+        )
+        fields["vacation_days"] = st.text_input("Urlaubstage / Vacation Days", fields.get("vacation_days", ""))
+        fields["remote_work_policy"] = st.text_area("Remote-Regelung / Remote Work Policy", fields.get("remote_work_policy", ""))
+        fields["flexible_hours"] = st.text_input("Flexible Arbeitszeiten / Flexible Hours", fields.get("flexible_hours", ""))
+        fields["relocation_assistance"] = st.text_area("Umzugshilfe / Relocation Assistance", fields.get("relocation_assistance", ""))
+        fields["childcare_support"] = st.text_area("Kinderbetreuung / Childcare Support", fields.get("childcare_support", ""))
+    st.session_state["job_fields"] = fields
+
+
+def wizard_step_8_recruitment() -> None:
+    """Step 8: recruitment process."""
+    fields = st.session_state.get("job_fields", {})
+    st.header("8. Bewerbungsprozess / Recruitment Process")
+    display_fields_editable()
+    fields["recruitment_contact_email"] = st.text_input(
+        "Recruiting-Kontakt E-Mail * / Contact Email *", fields.get("recruitment_contact_email", "")
+    )
+    with st.expander("Weitere Angaben / More Options"):
+        fields["recruitment_steps"] = st.text_area(
+            "Prozessschritte / Recruitment Steps", fields.get("recruitment_steps", "")
+        )
+        fields["recruitment_timeline"] = st.text_input(
+            "Zeitleiste / Recruitment Timeline", fields.get("recruitment_timeline", "")
+        )
+        fields["number_of_interviews"] = st.text_input(
+            "Anzahl Interviews / Number of Interviews", fields.get("number_of_interviews", "")
+        )
+        fields["interview_format"] = st.text_input("Interviewformat / Interview Format", fields.get("interview_format", ""))
+        fields["assessment_tests"] = st.text_area("Assessment-Tests", fields.get("assessment_tests", ""))
+        fields["onboarding_process_overview"] = st.text_area(
+            "Onboarding-Prozess / Onboarding Process", fields.get("onboarding_process_overview", "")
+        )
+        fields["recruitment_contact_phone"] = st.text_input(
+            "Telefon Recruiting-Kontakt / Contact Phone", fields.get("recruitment_contact_phone", "")
+        )
+        fields["application_instructions"] = st.text_area(
+            "Bewerbungsanweisungen / Application Instructions", fields.get("application_instructions", "")
+        )
+    st.session_state["job_fields"] = fields


### PR DESCRIPTION
## Summary
- implement multi-step wizard with navigation
- add job info extraction utilities

## Testing
- `python3 -m py_compile app.py wizard_steps.py utils/utils_jobinfo.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fef5771988320b49ffd8fb5b7c229