### PR TITLE
fix: add missing python-docx dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Need_Analysis
+
+Simple Streamlit app to extract information from job related
+documents. Install dependencies from `requirements.txt` before running:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the Streamlit app:
+
+```bash
+streamlit run app.py
+```
+

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 PyMuPDF
 openai
 requests
+python-docx

--- a/utils/utils_jobinfo.py
+++ b/utils/utils_jobinfo.py
@@ -76,7 +76,9 @@ def display_fields_editable() -> None:
 def export_fields_as_markdown() -> None:
     """Provide a download link for the stored fields as Markdown."""
     fields = st.session_state.get("job_fields", {})
-    md = "\n".join(f"**{k.replace('_', ' ').capitalize()}:** {v}" for k, v in fields.items())
+    md = "\n".join(
+        f"**{k.replace('_', ' ').capitalize()}:** {v}" for k, v in fields.items()
+    )
     b64 = base64.b64encode(md.encode()).decode()
     href = (
         f'<a href="data:text/markdown;base64,{b64}" download="jobinfo.md">'


### PR DESCRIPTION
## Summary
- add `python-docx` to dependencies
- add simple project instructions
- configure `mypy` to ignore missing imports
- format utils module

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ff2f2c7608320b346418154d3ce8f