### PR TITLE
fix: improve regex to detect job fields

### DIFF
--- a/utils/utils_jobinfo.py
+++ b/utils/utils_jobinfo.py
@@ -50,13 +50,23 @@ def extract_text(file) -> str:
 
 def basic_field_extraction(text: str) -> Dict[str, str]:
     """Naive regex extraction of some fields from text."""
+
     fields: Dict[str, str] = {}
-    job_title = re.search(r"(?i)(Stellenbezeichnung|Jobtitel|Position):?\s*(.+)", text)
+
+    job_title = re.search(
+        r"(?im)^\s*(Stellenbezeichnung|Jobtitel|Position)\s*[:\-]\s*(.+)$",
+        text,
+    )
     if job_title:
         fields["job_title"] = job_title.group(2).strip()
-    company_name = re.search(r"(?i)(Unternehmen|Company|Firma):?\s*(.+)", text)
+
+    company_name = re.search(
+        r"(?im)^\s*(Unternehmen|Company|Firma)\s*[:\-]\s*(.+)$",
+        text,
+    )
     if company_name:
         fields["company_name"] = company_name.group(2).strip()
+
     return fields
 
 


### PR DESCRIPTION
## Summary
- tighten regex for job title and company name extraction

## Testing
- `ruff check .`
- `black . --check`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ffb33a8788320a3afaa28fc632040