### PR TITLE
feat: language toggle and updated layout

### DIFF
--- a/utils/i18n.py
+++ b/utils/i18n.py
@@ -1,0 +1,11 @@
+"""Simple i18n helpers."""
+
+from __future__ import annotations
+
+
+def tr(text: str, lang: str) -> str:
+    """Return language specific part of a 'de / en' string."""
+    if " / " in text:
+        left, right = text.split(" / ", 1)
+        return left.strip() if lang == "de" else right.strip()
+    return text

--- a/utils/utils_jobinfo.py
+++ b/utils/utils_jobinfo.py
@@ -7,6 +7,8 @@ import base64
 import re
 from typing import Dict, Optional
 
+from utils.i18n import tr
+
 import docx
 import fitz  # PyMuPDF
 import streamlit as st
@@ -78,7 +80,8 @@ def save_fields_to_session(fields: Dict[str, str]) -> None:
 def display_fields_editable() -> None:
     """Show all stored fields as editable inputs."""
     fields = st.session_state.get("job_fields", {})
-    st.markdown("### Extrahierte Jobdaten / Extracted Job Info")
+    lang = st.session_state.get("lang", "de")
+    st.markdown(tr("### Extrahierte Jobdaten / Extracted Job Info", lang))
     for key, value in fields.items():
         st.text_input(key.replace("_", " ").title(), value, key=f"edit_{key}")
 
@@ -86,13 +89,14 @@ def display_fields_editable() -> None:
 def export_fields_as_markdown() -> None:
     """Provide a download link for the stored fields as Markdown."""
     fields = st.session_state.get("job_fields", {})
+    lang = st.session_state.get("lang", "de")
     md = "\n".join(
         f"**{k.replace('_', ' ').capitalize()}:** {v}" for k, v in fields.items()
     )
     b64 = base64.b64encode(md.encode()).decode()
     href = (
         f'<a href="data:text/markdown;base64,{b64}" download="jobinfo.md">'
-        "Markdown herunterladen / Download Markdown</a>"
+        f"{tr('Markdown herunterladen / Download Markdown', lang)}</a>"
     )
     st.markdown(href, unsafe_allow_html=True)
 
@@ -100,6 +104,7 @@ def export_fields_as_markdown() -> None:
 def display_all_fields_multiline_copy() -> None:
     """Show fields as multiline text areas."""
     fields = st.session_state.get("job_fields", {})
-    st.markdown("### Alle Felder / All Fields")
+    lang = st.session_state.get("lang", "de")
+    st.markdown(tr("### Alle Felder / All Fields", lang))
     for key, value in fields.items():
         st.text_area(key.replace("_", " ").title(), value, key=f"multi_{key}")

--- a/wizard_steps.py
+++ b/wizard_steps.py
@@ -4,26 +4,71 @@ from __future__ import annotations
 
 import streamlit as st
 
-from utils.utils_jobinfo import display_fields_editable
+from utils.utils_jobinfo import (
+    display_fields_editable,
+    basic_field_extraction,
+    extract_text,
+    save_fields_to_session,
+)
+from utils.i18n import tr
+import requests
 
 
 def wizard_step_1_basic() -> None:
     """Step 1: capture basic job data."""
-    st.header("1. Grunddaten / Basic Data")
+    lang = st.session_state.get("lang", "de")
+    st.header(tr("1. Grunddaten / Basic Data", lang))
     st.subheader(
-        "Das Tool hilft Linemanagern, Informationsverluste im Recruiting zu vermeiden "
-        "und den besten Kandidaten langfristig zu binden."
+        tr(
+            "Das Tool hilft Linemanagern, Informationsverluste im Recruiting zu vermeiden und den besten Kandidaten langfristig zu binden. / "
+            "The tool helps line managers avoid losing information in recruiting and retain the best candidates long-term.",
+            lang,
+        )
     )
     fields = st.session_state.get("job_fields", {})
     job_title = st.text_input(
-        "Jobtitel / Job Title *",
+        tr("Jobtitel / Job Title *", lang),
         fields.get("job_title", ""),
     )
     if fields:
         display_fields_editable()
 
     if not job_title:
-        st.warning("Bitte Jobtitel eingeben. / Please enter job title.")
+        st.warning(tr("Bitte Jobtitel eingeben. / Please enter job title.", lang))
+
+    uploaded_file = st.file_uploader(
+        tr(
+            "W\u00e4hle eine Datei (PDF, DOCX, TXT) / Choose a file (PDF, DOCX, TXT)",
+            lang,
+        ),
+        type=["pdf", "docx", "txt"],
+    )
+    url_input = st.text_input(tr("...oder gib eine URL ein / ...or enter a URL", lang))
+
+    if uploaded_file or url_input:
+        if (
+            uploaded_file
+            and "last_uploaded" not in st.session_state
+            or (
+                uploaded_file
+                and uploaded_file.name != st.session_state.get("last_uploaded", None)
+            )
+        ):
+            text = extract_text(uploaded_file)
+            fields_update = basic_field_extraction(text)
+            save_fields_to_session(fields_update)
+            st.session_state["last_uploaded"] = uploaded_file.name
+
+        if url_input and url_input != st.session_state.get("last_url", ""):
+            try:  # pragma: no cover - network
+                response = requests.get(url_input, timeout=10)
+                response.raise_for_status()
+                text = response.text
+                fields_update = basic_field_extraction(text)
+                save_fields_to_session(fields_update)
+                st.session_state["last_url"] = url_input
+            except Exception as exc:  # pragma: no cover - network
+                st.error(f"Fehler beim Laden der URL: {exc}")
 
     fields["job_title"] = job_title
     st.session_state["job_fields"] = fields
@@ -31,152 +76,171 @@ def wizard_step_1_basic() -> None:
 
 def wizard_step_2_company() -> None:
     """Step 2: company information."""
+    lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
-    st.header(f"2. Unternehmensdaten / Company Info – {fields.get('company_name', '')}")
+    st.header(
+        tr(
+            f"2. Unternehmensdaten / Company Info – {fields.get('company_name', '')}",
+            lang,
+        )
+    )
     st.subheader(
-        "Transparente Unternehmensinfos erleichtern Kandidaten die Entscheidung."
+        tr(
+            "Transparente Unternehmensinfos erleichtern Kandidaten die Entscheidung. / Transparent company info helps candidates decide.",
+            lang,
+        )
     )
     display_fields_editable()
     fields["company_name"] = st.text_input(
-        "Unternehmen / Company Name *", fields.get("company_name", "")
+        tr("Unternehmen / Company Name *", lang), fields.get("company_name", "")
     )
-    fields["city"] = st.text_input("Stadt / City *", fields.get("city", ""))
-    with st.expander("Weitere Angaben / More"):
+    fields["city"] = st.text_input(tr("Stadt / City *", lang), fields.get("city", ""))
+    with st.expander(tr("Weitere Angaben / More", lang)):
         fields["headquarters_location"] = st.text_input(
-            "Hauptsitz / Headquarters Location", fields.get("headquarters_location", "")
+            tr("Hauptsitz / Headquarters Location", lang),
+            fields.get("headquarters_location", ""),
         )
         fields["company_website"] = st.text_input(
-            "Unternehmenswebsite / Company Website", fields.get("company_website", "")
+            tr("Unternehmenswebsite / Company Website", lang),
+            fields.get("company_website", ""),
         )
     st.session_state["job_fields"] = fields
 
 
 def wizard_step_3_department() -> None:
     """Step 3: department and team."""
+    lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
-    st.header("3. Abteilung & Team / Department and Team Info")
+    st.header(tr("3. Abteilung & Team / Department and Team Info", lang))
     display_fields_editable()
-    with st.expander("Team/Abteilung (optional)"):
+    with st.expander(tr("Team/Abteilung (optional)", lang)):
         fields["brand_name"] = st.text_input(
-            "Markenname / Brand Name", fields.get("brand_name", "")
+            tr("Markenname / Brand Name", lang), fields.get("brand_name", "")
         )
         fields["team_structure"] = st.text_area(
-            "Teamstruktur / Team Structure", fields.get("team_structure", "")
+            tr("Teamstruktur / Team Structure", lang), fields.get("team_structure", "")
         )
     st.session_state["job_fields"] = fields
 
 
 def wizard_step_4_role() -> None:
     """Step 4: role definition."""
+    lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
-    st.header("4. Rollen-Definition / Role Definition")
+    st.header(tr("4. Rollen-Definition / Role Definition", lang))
     display_fields_editable()
     fields["job_type"] = st.selectbox(
-        "Jobart / Job Type *",
+        tr("Jobart / Job Type *", lang),
         [
-            "Vollzeit / Full-Time",
-            "Teilzeit / Part-Time",
-            "Praktikum / Internship",
+            tr("Vollzeit / Full-Time", lang),
+            tr("Teilzeit / Part-Time", lang),
+            tr("Praktikum / Internship", lang),
             "Freelance",
         ],
         index=0,
     )
     fields["contract_type"] = st.selectbox(
-        "Vertragstyp / Contract Type *",
+        tr("Vertragstyp / Contract Type *", lang),
         [
-            "Unbefristet / Permanent",
-            "Befristet / Fixed-term",
-            "Werkvertrag / Contract for Work",
+            tr("Unbefristet / Permanent", lang),
+            tr("Befristet / Fixed-term", lang),
+            tr("Werkvertrag / Contract for Work", lang),
         ],
         index=0,
     )
     fields["job_level"] = st.selectbox(
-        "Karrierelevel / Job Level *",
+        tr("Karrierelevel / Job Level *", lang),
         ["Junior", "Mid", "Senior", "Lead", "Management"],
         index=0,
     )
     fields["role_description"] = st.text_area(
-        "Rollenbeschreibung / Role Description *", fields.get("role_description", "")
+        tr("Rollenbeschreibung / Role Description *", lang),
+        fields.get("role_description", ""),
     )
     fields["role_type"] = st.text_input(
-        "Rollentyp / Role Type *", fields.get("role_type", "")
+        tr("Rollentyp / Role Type *", lang), fields.get("role_type", "")
     )
-    with st.expander("Weitere Optionen / More Options"):
+    with st.expander(tr("Weitere Optionen / More Options", lang)):
         fields["date_of_employment_start"] = st.date_input(
-            "Startdatum / Start Date", fields.get("date_of_employment_start", None)
+            tr("Startdatum / Start Date", lang),
+            fields.get("date_of_employment_start", None),
         )
         fields["role_performance_metrics"] = st.text_area(
-            "Leistungskennzahlen / Performance Metrics",
+            tr("Leistungskennzahlen / Performance Metrics", lang),
             fields.get("role_performance_metrics", ""),
         )
         fields["role_priority_projects"] = st.text_area(
-            "Prioritätsprojekte / Priority Projects",
+            tr("Prioritätsprojekte / Priority Projects", lang),
             fields.get("role_priority_projects", ""),
         )
         fields["travel_requirements"] = st.text_input(
-            "Reisebereitschaft / Travel Requirements",
+            tr("Reisebereitschaft / Travel Requirements", lang),
             fields.get("travel_requirements", ""),
         )
         fields["work_schedule"] = st.text_input(
-            "Arbeitszeiten / Work Schedule", fields.get("work_schedule", "")
+            tr("Arbeitszeiten / Work Schedule", lang), fields.get("work_schedule", "")
         )
         fields["role_keywords"] = st.text_input(
-            "Schlüsselwörter / Role Keywords", fields.get("role_keywords", "")
+            tr("Schlüsselwörter / Role Keywords", lang), fields.get("role_keywords", "")
         )
         fields["decision_making_authority"] = st.text_input(
-            "Entscheidungskompetenz / Decision Making Authority",
+            tr("Entscheidungskompetenz / Decision Making Authority", lang),
             fields.get("decision_making_authority", ""),
         )
-    with st.expander("Fortgeschritten / Advanced", expanded=False):
+    with st.expander(tr("Fortgeschritten / Advanced", lang), expanded=False):
         fields["reports_to"] = st.text_input(
-            "Berichtet an / Reports To", fields.get("reports_to", "")
+            tr("Berichtet an / Reports To", lang), fields.get("reports_to", "")
         )
         fields["supervises"] = st.text_input(
-            "Führungsspanne / Supervises", fields.get("supervises", "")
+            tr("Führungsspanne / Supervises", lang), fields.get("supervises", "")
         )
     st.session_state["job_fields"] = fields
 
 
 def wizard_step_5_tasks() -> None:
     """Step 5: tasks and responsibilities."""
+    lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
-    st.header("5. Aufgaben & Verantwortlichkeiten / Tasks & Responsibilities")
+    st.header(tr("5. Aufgaben & Verantwortlichkeiten / Tasks & Responsibilities", lang))
     display_fields_editable()
     fields["task_list"] = st.text_area(
-        "Aufgabenliste / Task List *", fields.get("task_list", "")
+        tr("Aufgabenliste / Task List *", lang), fields.get("task_list", "")
     )
-    with st.expander("Weitere Aufgaben / More Tasks"):
+    with st.expander(tr("Weitere Aufgaben / More Tasks", lang)):
         fields["key_responsibilities"] = st.text_area(
-            "Hauptverantwortlichkeiten / Key Responsibilities",
+            tr("Hauptverantwortlichkeiten / Key Responsibilities", lang),
             fields.get("key_responsibilities", ""),
         )
         fields["technical_tasks"] = st.text_area(
-            "Technische Aufgaben / Technical Tasks", fields.get("technical_tasks", "")
+            tr("Technische Aufgaben / Technical Tasks", lang),
+            fields.get("technical_tasks", ""),
         )
         fields["managerial_tasks"] = st.text_area(
-            "Managementaufgaben / Managerial Tasks", fields.get("managerial_tasks", "")
+            tr("Managementaufgaben / Managerial Tasks", lang),
+            fields.get("managerial_tasks", ""),
         )
         fields["administrative_tasks"] = st.text_area(
-            "Administrative Aufgaben / Administrative Tasks",
+            tr("Administrative Aufgaben / Administrative Tasks", lang),
             fields.get("administrative_tasks", ""),
         )
         fields["customer_facing_tasks"] = st.text_area(
-            "Kundenkontakt / Customer Facing Tasks",
+            tr("Kundenkontakt / Customer Facing Tasks", lang),
             fields.get("customer_facing_tasks", ""),
         )
         fields["internal_reporting_tasks"] = st.text_area(
-            "Reporting intern / Internal Reporting Tasks",
+            tr("Reporting intern / Internal Reporting Tasks", lang),
             fields.get("internal_reporting_tasks", ""),
         )
         fields["performance_tasks"] = st.text_area(
-            "Performance-Aufgaben / Performance Tasks",
+            tr("Performance-Aufgaben / Performance Tasks", lang),
             fields.get("performance_tasks", ""),
         )
         fields["innovation_tasks"] = st.text_area(
-            "Innovationsaufgaben / Innovation Tasks", fields.get("innovation_tasks", "")
+            tr("Innovationsaufgaben / Innovation Tasks", lang),
+            fields.get("innovation_tasks", ""),
         )
         fields["task_prioritization"] = st.text_area(
-            "Aufgabenpriorisierung / Task Prioritization",
+            tr("Aufgabenpriorisierung / Task Prioritization", lang),
             fields.get("task_prioritization", ""),
         )
     st.session_state["job_fields"] = fields
@@ -184,147 +248,164 @@ def wizard_step_5_tasks() -> None:
 
 def wizard_step_6_skills() -> None:
     """Step 6: required skills."""
+    lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
-    st.header("6. Skills & Kompetenzen / Skills & Competencies")
+    st.header(tr("6. Skills & Kompetenzen / Skills & Competencies", lang))
     display_fields_editable()
     fields["must_have_skills"] = st.text_area(
-        "Must-have Skills *", fields.get("must_have_skills", "")
+        tr("Must-have Skills *", lang), fields.get("must_have_skills", "")
     )
-    with st.expander("Weitere Skills / More Skills"):
+    with st.expander(tr("Weitere Skills / More Skills", lang)):
         fields["hard_skills"] = st.text_area(
-            "Hard Skills", fields.get("hard_skills", "")
+            tr("Hard Skills", lang), fields.get("hard_skills", "")
         )
         fields["soft_skills"] = st.text_area(
-            "Soft Skills", fields.get("soft_skills", "")
+            tr("Soft Skills", lang), fields.get("soft_skills", "")
         )
         fields["nice_to_have_skills"] = st.text_area(
-            "Nice-to-have Skills", fields.get("nice_to_have_skills", "")
+            tr("Nice-to-have Skills", lang), fields.get("nice_to_have_skills", "")
         )
         fields["certifications_required"] = st.text_area(
-            "Zertifikate / Certifications Required",
+            tr("Zertifikate / Certifications Required", lang),
             fields.get("certifications_required", ""),
         )
         fields["language_requirements"] = st.text_area(
-            "Sprachkenntnisse / Language Requirements",
+            tr("Sprachkenntnisse / Language Requirements", lang),
             fields.get("language_requirements", ""),
         )
         fields["tool_proficiency"] = st.text_area(
-            "Toolkenntnisse / Tool Proficiency", fields.get("tool_proficiency", "")
+            tr("Toolkenntnisse / Tool Proficiency", lang),
+            fields.get("tool_proficiency", ""),
         )
         fields["technical_stack"] = st.text_area(
-            "Technischer Stack / Technical Stack", fields.get("technical_stack", "")
+            tr("Technischer Stack / Technical Stack", lang),
+            fields.get("technical_stack", ""),
         )
         fields["domain_expertise"] = st.text_area(
-            "Fachexpertise / Domain Expertise", fields.get("domain_expertise", "")
+            tr("Fachexpertise / Domain Expertise", lang),
+            fields.get("domain_expertise", ""),
         )
         fields["leadership_competencies"] = st.text_area(
-            "Leadership-Kompetenzen / Leadership Competencies",
+            tr("Leadership-Kompetenzen / Leadership Competencies", lang),
             fields.get("leadership_competencies", ""),
         )
         fields["industry_experience"] = st.text_area(
-            "Branchenerfahrung / Industry Experience",
+            tr("Branchenerfahrung / Industry Experience", lang),
             fields.get("industry_experience", ""),
         )
         fields["analytical_skills"] = st.text_area(
-            "Analytische Fähigkeiten / Analytical Skills",
+            tr("Analytische Fähigkeiten / Analytical Skills", lang),
             fields.get("analytical_skills", ""),
         )
         fields["communication_skills"] = st.text_area(
-            "Kommunikationsfähigkeiten / Communication Skills",
+            tr("Kommunikationsfähigkeiten / Communication Skills", lang),
             fields.get("communication_skills", ""),
         )
         fields["project_management_skills"] = st.text_area(
-            "Projektmanagement / Project Management Skills",
+            tr("Projektmanagement / Project Management Skills", lang),
             fields.get("project_management_skills", ""),
         )
         fields["soft_requirement_details"] = st.text_area(
-            "Details zu Soft Requirements", fields.get("soft_requirement_details", "")
+            tr("Details zu Soft Requirements", lang),
+            fields.get("soft_requirement_details", ""),
         )
         fields["visa_sponsorship"] = st.text_input(
-            "Visa Sponsorship", fields.get("visa_sponsorship", "")
+            tr("Visa Sponsorship", lang), fields.get("visa_sponsorship", "")
         )
     st.session_state["job_fields"] = fields
 
 
 def wizard_step_7_compensation() -> None:
     """Step 7: compensation and benefits."""
+    lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
-    st.header("7. Vergütung & Benefits / Compensation & Benefits")
+    st.header(tr("7. Vergütung & Benefits / Compensation & Benefits", lang))
     display_fields_editable()
     fields["salary_range"] = st.text_input(
-        "Gehaltsrange / Salary Range *", fields.get("salary_range", "")
+        tr("Gehaltsrange / Salary Range *", lang), fields.get("salary_range", "")
     )
     fields["currency"] = st.selectbox(
-        "Währung / Currency *", ["EUR", "CHF", "GBP", "USD", "other"], index=0
+        tr("Währung / Currency *", lang), ["EUR", "CHF", "GBP", "USD", "other"], index=0
     )
     fields["pay_frequency"] = st.selectbox(
-        "Auszahlungsrhythmus / Pay Frequency *",
-        ["Monatlich / Monthly", "Jährlich / Annually", "Wöchentlich / Weekly"],
+        tr("Auszahlungsrhythmus / Pay Frequency *", lang),
+        [
+            tr("Monatlich / Monthly", lang),
+            tr("Jährlich / Annually", lang),
+            tr("Wöchentlich / Weekly", lang),
+        ],
         index=0,
     )
-    with st.expander("Weitere Benefits / More Benefits"):
+    with st.expander(tr("Weitere Benefits / More Benefits", lang)):
         fields["bonus_scheme"] = st.text_area(
-            "Bonusregelung / Bonus Scheme", fields.get("bonus_scheme", "")
+            tr("Bonusregelung / Bonus Scheme", lang), fields.get("bonus_scheme", "")
         )
         fields["commission_structure"] = st.text_area(
-            "Provisionsmodell / Commission Structure",
+            tr("Provisionsmodell / Commission Structure", lang),
             fields.get("commission_structure", ""),
         )
         fields["vacation_days"] = st.text_input(
-            "Urlaubstage / Vacation Days", fields.get("vacation_days", "")
+            tr("Urlaubstage / Vacation Days", lang), fields.get("vacation_days", "")
         )
         fields["remote_work_policy"] = st.text_area(
-            "Remote-Regelung / Remote Work Policy", fields.get("remote_work_policy", "")
+            tr("Remote-Regelung / Remote Work Policy", lang),
+            fields.get("remote_work_policy", ""),
         )
         fields["flexible_hours"] = st.text_input(
-            "Flexible Arbeitszeiten / Flexible Hours", fields.get("flexible_hours", "")
+            tr("Flexible Arbeitszeiten / Flexible Hours", lang),
+            fields.get("flexible_hours", ""),
         )
         fields["relocation_assistance"] = st.text_area(
-            "Umzugshilfe / Relocation Assistance",
+            tr("Umzugshilfe / Relocation Assistance", lang),
             fields.get("relocation_assistance", ""),
         )
         fields["childcare_support"] = st.text_area(
-            "Kinderbetreuung / Childcare Support", fields.get("childcare_support", "")
+            tr("Kinderbetreuung / Childcare Support", lang),
+            fields.get("childcare_support", ""),
         )
     st.session_state["job_fields"] = fields
 
 
 def wizard_step_8_recruitment() -> None:
     """Step 8: recruitment process."""
+    lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
-    st.header("8. Bewerbungsprozess / Recruitment Process")
+    st.header(tr("8. Bewerbungsprozess / Recruitment Process", lang))
     display_fields_editable()
     fields["recruitment_contact_email"] = st.text_input(
-        "Recruiting-Kontakt E-Mail * / Contact Email *",
+        tr("Recruiting-Kontakt E-Mail * / Contact Email *", lang),
         fields.get("recruitment_contact_email", ""),
     )
-    with st.expander("Weitere Angaben / More Options"):
+    with st.expander(tr("Weitere Angaben / More Options", lang)):
         fields["recruitment_steps"] = st.text_area(
-            "Prozessschritte / Recruitment Steps", fields.get("recruitment_steps", "")
+            tr("Prozessschritte / Recruitment Steps", lang),
+            fields.get("recruitment_steps", ""),
         )
         fields["recruitment_timeline"] = st.text_input(
-            "Zeitleiste / Recruitment Timeline", fields.get("recruitment_timeline", "")
+            tr("Zeitleiste / Recruitment Timeline", lang),
+            fields.get("recruitment_timeline", ""),
         )
         fields["number_of_interviews"] = st.text_input(
-            "Anzahl Interviews / Number of Interviews",
+            tr("Anzahl Interviews / Number of Interviews", lang),
             fields.get("number_of_interviews", ""),
         )
         fields["interview_format"] = st.text_input(
-            "Interviewformat / Interview Format", fields.get("interview_format", "")
+            tr("Interviewformat / Interview Format", lang),
+            fields.get("interview_format", ""),
         )
         fields["assessment_tests"] = st.text_area(
-            "Assessment-Tests", fields.get("assessment_tests", "")
+            tr("Assessment-Tests", lang), fields.get("assessment_tests", "")
         )
         fields["onboarding_process_overview"] = st.text_area(
-            "Onboarding-Prozess / Onboarding Process",
+            tr("Onboarding-Prozess / Onboarding Process", lang),
             fields.get("onboarding_process_overview", ""),
         )
         fields["recruitment_contact_phone"] = st.text_input(
-            "Telefon Recruiting-Kontakt / Contact Phone",
+            tr("Telefon Recruiting-Kontakt / Contact Phone", lang),
             fields.get("recruitment_contact_phone", ""),
         )
         fields["application_instructions"] = st.text_area(
-            "Bewerbungsanweisungen / Application Instructions",
+            tr("Bewerbungsanweisungen / Application Instructions", lang),
             fields.get("application_instructions", ""),
         )
     st.session_state["job_fields"] = fields


### PR DESCRIPTION
## Summary
- add i18n helper with `tr` function
- move file upload into wizard step and show step navigation in main area
- add language toggle and styling to `app.py`
- localize labels across wizard steps

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685007dadf3c8320a0203d89d0bbf02f