### PR TITLE
fix: add requests stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Need_Analysis
 
 Simple Streamlit app to extract information from job related
-documents. Install dependencies from `requirements.txt` before running:
+documents. Install dependencies from `requirements.txt` before running
+(includes `types-requests` for MyPy):
 
 ```bash
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyMuPDF
 openai
 requests
 python-docx
+types-requests


### PR DESCRIPTION
## Summary
- install `types-requests` so mypy finds request type hints
- note stub package in README

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68500913dc9483208d2e7cc53686f09d