### PR TITLE
Add ESCO skill search

### DIFF
--- a/utils/esco_client.py
+++ b/utils/esco_client.py
@@ -1,0 +1,40 @@
+"""Client for interacting with the ESCO REST API."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Union
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://ec.europa.eu/esco/api"
+
+
+def search_skills(query: str, *, language: str = "en", limit: int = 10) -> List[str]:
+    """Search skills in ESCO and return a list of titles.
+
+    Args:
+        query: Text query for the search endpoint.
+        language: ISO language code, defaults to "en".
+        limit: Maximum number of results to return.
+
+    Returns:
+        List of skill titles.
+    """
+    params: Dict[str, Union[str, int]] = {
+        "text": query,
+        "language": language,
+        "type": "skill",
+        "limit": limit,
+    }
+    try:
+        response = requests.get(f"{BASE_URL}/search", params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        results = data.get("_embedded", {}).get("results", [])
+        return [r.get("title") for r in results if r.get("title")]
+    except Exception as exc:  # pragma: no cover - network
+        logger.warning("ESCO API request failed: %s", exc)
+        return []

--- a/wizard_steps.py
+++ b/wizard_steps.py
@@ -11,6 +11,7 @@ from utils.utils_jobinfo import (
     save_fields_to_session,
 )
 from utils.i18n import tr
+from utils.esco_client import search_skills
 import requests
 
 
@@ -251,6 +252,15 @@ def wizard_step_6_skills() -> None:
     lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
     st.header(tr("6. Skills & Kompetenzen / Skills & Competencies", lang))
+    skill_query = st.text_input(
+        tr("Skill bei ESCO suchen / Search skill in ESCO", lang)
+    )
+    if skill_query:
+        suggestions = search_skills(skill_query, language=lang, limit=5)
+        if suggestions:
+            st.info(", ".join(suggestions))
+        else:
+            st.warning(tr("Keine Ergebnisse von ESCO", lang))
     display_fields_editable(prefix="step6_")
     fields["must_have_skills"] = st.text_area(
         tr("Must-have Skills *", lang), fields.get("must_have_skills", "")


### PR DESCRIPTION
## Summary
- add `utils.esco_client` for ESCO REST API calls
- integrate skill search in the "Skills" wizard step

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68502a32ac788320b5a6044d1e098769