### PR TITLE
fix: reset widget key tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,9 @@ from wizard_steps import (
 
 st.set_page_config(page_title="Vacalyser Wizard", layout="wide")
 
+# Reset widget key tracking each run to avoid stale keys
+st.session_state["_used_widget_keys"] = set()
+
 # --- Global language toggle ------------------------------------------------
 if "lang" not in st.session_state:
     st.session_state["lang"] = "de"


### PR DESCRIPTION
## Summary
- avoid stale widget keys by resetting `_used_widget_keys` on each run

## Testing
- `ruff check .`
- `black . --check`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503e01ab9083208653cfeda4028ebe