### PR TITLE
feat: extract skills from job text

### DIFF
--- a/tests/test_utils_jobinfo.py
+++ b/tests/test_utils_jobinfo.py
@@ -1,0 +1,10 @@
+from utils.utils_jobinfo import basic_field_extraction
+
+
+def test_basic_field_extraction_skills():
+    text = "Proficiency in Python and machine learning libraries (e.g., scikit-learn, TensorFlow)."
+    result = basic_field_extraction(text)
+    assert (
+        result["must_have_skills"]
+        == "Python, machine learning libraries, scikit-learn, TensorFlow"
+    )


### PR DESCRIPTION
## Summary
- parse 'Proficiency in …' phrases in `basic_field_extraction`
- return detected skills as `must_have_skills`
- add unit test for skill extraction

## Testing
- `ruff check .`
- `black .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685060acb7288320aedcc63254c37e31