### PR TITLE
feat: update wizard UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ import streamlit as st
 from utils.utils_jobinfo import (
     display_all_fields_multiline_copy,
     display_fields_editable,
-    export_fields_as_markdown,
 )
 from utils.i18n import tr
 from wizard_steps import (
@@ -83,13 +82,14 @@ wizard_steps[step_idx][1]()
 
 # --- Utility-Optionen nach dem Wizard ------------------------------------
 st.markdown("---")
-st.header(tr("Extras & Export", lang))
-st.subheader(tr("1. Editierbare Felder / Editable Fields", lang))
-display_fields_editable()
-st.subheader(tr("2. Export als Markdown", lang))
-export_fields_as_markdown()
-st.subheader(tr("3. Mehrzeilige Ansicht (Copy & Paste)", lang))
-display_all_fields_multiline_copy()
+with st.expander(tr("Extras & Export", lang), expanded=False):
+    col1, col2 = st.columns(2)
+    with col1:
+        st.subheader(tr("1. Editierbare Felder / Editable Fields", lang))
+        display_fields_editable()
+    with col2:
+        st.subheader(tr("3. Mehrzeilige Ansicht (Copy & Paste)", lang))
+        display_all_fields_multiline_copy()
 
 if st.checkbox(tr("Session State anzeigen / Show Session State [DEV]", lang)):
     st.write(st.session_state)

--- a/utils/utils_jobinfo.py
+++ b/utils/utils_jobinfo.py
@@ -79,6 +79,21 @@ def save_fields_to_session(fields: Dict[str, str]) -> None:
     st.session_state.setdefault("job_fields", {}).update(fields)
 
 
+def display_fields_summary() -> None:
+    """Show extracted fields as two-line bullet points."""
+
+    fields = st.session_state.get("job_fields", {})
+    lang = st.session_state.get("lang", "de")
+
+    st.markdown(tr("### Extrahierte Jobdaten / Extracted Job Info", lang))
+    st.markdown("<style>.field-bullet{font-size:16px;}</style>", unsafe_allow_html=True)
+    for key, value in fields.items():
+        st.markdown(
+            f"- **{key.replace('_', ' ').title()}**<br>{value}",
+            unsafe_allow_html=True,
+        )
+
+
 def display_fields_editable(prefix: str = "edit_") -> None:
     """Show all stored fields as editable inputs.
 

--- a/wizard_steps.py
+++ b/wizard_steps.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import streamlit as st
 
 from utils.utils_jobinfo import (
-    display_fields_editable,
+    display_fields_summary,
     basic_field_extraction,
     extract_text,
     save_fields_to_session,
@@ -32,7 +32,7 @@ def wizard_step_1_basic() -> None:
         fields.get("job_title", ""),
     )
     if fields:
-        display_fields_editable(prefix="step1_")
+        display_fields_summary()
 
     if not job_title:
         st.warning(tr("Bitte Jobtitel eingeben. / Please enter job title.", lang))
@@ -91,7 +91,7 @@ def wizard_step_2_company() -> None:
             lang,
         )
     )
-    display_fields_editable(prefix="step2_")
+    display_fields_summary()
     fields["company_name"] = st.text_input(
         tr("Unternehmen / Company Name *", lang), fields.get("company_name", "")
     )
@@ -113,7 +113,7 @@ def wizard_step_3_department() -> None:
     lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
     st.header(tr("3. Abteilung & Team / Department and Team Info", lang))
-    display_fields_editable(prefix="step3_")
+    display_fields_summary()
     with st.expander(tr("Team/Abteilung (optional)", lang)):
         fields["brand_name"] = st.text_input(
             tr("Markenname / Brand Name", lang), fields.get("brand_name", "")
@@ -129,7 +129,7 @@ def wizard_step_4_role() -> None:
     lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
     st.header(tr("4. Rollen-Definition / Role Definition", lang))
-    display_fields_editable(prefix="step4_")
+    display_fields_summary()
     fields["job_type"] = st.selectbox(
         tr("Jobart / Job Type *", lang),
         [
@@ -203,7 +203,7 @@ def wizard_step_5_tasks() -> None:
     lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
     st.header(tr("5. Aufgaben & Verantwortlichkeiten / Tasks & Responsibilities", lang))
-    display_fields_editable(prefix="step5_")
+    display_fields_summary()
     fields["task_list"] = st.text_area(
         tr("Aufgabenliste / Task List *", lang), fields.get("task_list", "")
     )
@@ -261,7 +261,7 @@ def wizard_step_6_skills() -> None:
             st.info(", ".join(suggestions))
         else:
             st.warning(tr("Keine Ergebnisse von ESCO", lang))
-    display_fields_editable(prefix="step6_")
+    display_fields_summary()
     fields["must_have_skills"] = st.text_area(
         tr("Must-have Skills *", lang), fields.get("must_have_skills", "")
     )
@@ -330,7 +330,7 @@ def wizard_step_7_compensation() -> None:
     lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
     st.header(tr("7. Vergütung & Benefits / Compensation & Benefits", lang))
-    display_fields_editable(prefix="step7_")
+    display_fields_summary()
     fields["salary_range"] = st.text_input(
         tr("Gehaltsrange / Salary Range *", lang), fields.get("salary_range", "")
     )
@@ -381,7 +381,7 @@ def wizard_step_8_recruitment() -> None:
     lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
     st.header(tr("8. Bewerbungsprozess / Recruitment Process", lang))
-    display_fields_editable(prefix="step8_")
+    display_fields_summary()
     fields["recruitment_contact_email"] = st.text_input(
         tr("Recruiting-Kontakt E-Mail * / Contact Email *", lang),
         fields.get("recruitment_contact_email", ""),


### PR DESCRIPTION
## Summary
- add new `display_fields_summary` to show extracted fields as bulletpoints
- collapse "Extras & Export" section and arrange options in 2 columns
- replace editable previews in steps with bullet lists and drop markdown export

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685061c5c07c8320a26ef6079f838e0a