### PR TITLE
fix: use canonical field keys in boolean search

### DIFF
--- a/functions/boolean_search.py
+++ b/functions/boolean_search.py
@@ -1,11 +1,21 @@
-def generate_boolean_search(fields):
-    skills = fields.get("required_skills", [])
-    location = fields.get("location", "")
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def generate_boolean_search(fields: Dict[str, Any]) -> str:
+    """Return a basic Boolean search string for job ads."""
+
+    skills = fields.get("must_have_skills", [])
+    if isinstance(skills, str):
+        skills = [s.strip() for s in skills.split(",") if s.strip()]
+
+    city = fields.get("city", "")
     job_title = fields.get("job_title", "")
 
     if not skills or not job_title:
         return "# Nicht genug Daten für Boolean-String"
 
     skill_part = " OR ".join([f'"{skill}"' for skill in skills])
-    query = f'({skill_part}) AND "{job_title}" AND {location}'
+    query = f'({skill_part}) AND "{job_title}" AND {city}'
     return query

--- a/keys.py
+++ b/keys.py
@@ -118,3 +118,6 @@ GENERATED_KEYS: list[str] = [
     "target_group_analysis",
     "generated_boolean_query",
 ]
+
+# Flattened list of all user-facing field keys for convenience
+ALL_STEP_KEYS: list[str] = [key for step in STEP_KEYS.values() for key in step]

--- a/tests/test_boolean_search.py
+++ b/tests/test_boolean_search.py
@@ -1,0 +1,27 @@
+from functions.boolean_search import generate_boolean_search
+
+
+def test_generate_boolean_search_with_list():
+    fields = {
+        "must_have_skills": ["Python", "SQL"],
+        "city": "Berlin",
+        "job_title": "Data Scientist",
+    }
+    result = generate_boolean_search(fields)
+    assert result == '("Python" OR "SQL") AND "Data Scientist" AND Berlin'
+
+
+def test_generate_boolean_search_with_string():
+    fields = {
+        "must_have_skills": "Python, SQL",
+        "city": "Berlin",
+        "job_title": "Data Scientist",
+    }
+    result = generate_boolean_search(fields)
+    assert result == '("Python" OR "SQL") AND "Data Scientist" AND Berlin'
+
+
+def test_generate_boolean_search_missing_data():
+    fields = {"city": "Berlin"}
+    result = generate_boolean_search(fields)
+    assert result.startswith("# Nicht genug Daten")

--- a/tests/test_utils_jobinfo.py
+++ b/tests/test_utils_jobinfo.py
@@ -9,6 +9,7 @@ def test_basic_field_extraction_skills():
         result["must_have_skills"]
         == "Python, machine learning libraries, scikit-learn, TensorFlow"
     )
+    assert result["parsed_data_raw"] == text
 
 
 def test_extract_text_from_docx_with_table(tmp_path):
@@ -30,3 +31,4 @@ def test_extract_text_from_docx_with_table(tmp_path):
         fields["must_have_skills"]
         == "Python, machine learning libraries, scikit-learn, TensorFlow"
     )
+    assert fields["parsed_data_raw"] == text

--- a/utils/utils_jobinfo.py
+++ b/utils/utils_jobinfo.py
@@ -7,6 +7,8 @@ import base64
 import re
 from typing import Dict, Optional
 
+from keys import ALL_STEP_KEYS
+
 from utils.i18n import tr
 
 import docx
@@ -64,14 +66,15 @@ def extract_text(file) -> str:
 
 
 def basic_field_extraction(text: str) -> Dict[str, str]:
-    """Naive regex extraction of some fields from raw job text.
+    """Return a dictionary with extracted fields from ``text``.
 
-    Besides ``job_title`` and ``company_name`` this function tries to detect
-    simple skill statements like ``Proficiency in Python and ...``. Detected
-    skills are stored comma separated in ``must_have_skills``.
+    This naive regex approach detects ``job_title``, ``company_name`` and some
+    simple skill statements. The raw text is stored under ``parsed_data_raw``.
+    Any missing keys from :data:`keys.ALL_STEP_KEYS` are included with empty
+    strings so that Streamlit widgets can be pre-populated consistently.
     """
 
-    fields: Dict[str, str] = {}
+    fields: Dict[str, str] = {"parsed_data_raw": text}
 
     job_title = re.search(
         r"(?im)^\s*(Stellenbezeichnung|Jobtitel|Position)\s*[:\-]\s*(.+)$",
@@ -107,6 +110,9 @@ def basic_field_extraction(text: str) -> Dict[str, str]:
                 skills.append(part)
     if skills:
         fields["must_have_skills"] = ", ".join(skills)
+
+    for key in ALL_STEP_KEYS:
+        fields.setdefault(key, "")
 
     return fields
 

--- a/wizard_steps.py
+++ b/wizard_steps.py
@@ -57,6 +57,7 @@ def wizard_step_1_basic() -> None:
         ):
             text = extract_text(uploaded_file)
             fields_update = basic_field_extraction(text)
+            fields_update["uploaded_file"] = uploaded_file.name
             save_fields_to_session(fields_update)
             st.session_state["last_uploaded"] = uploaded_file.name
 
@@ -66,6 +67,7 @@ def wizard_step_1_basic() -> None:
                 response.raise_for_status()
                 text = response.text
                 fields_update = basic_field_extraction(text)
+                fields_update["input_url"] = url_input
                 save_fields_to_session(fields_update)
                 st.session_state["last_url"] = url_input
             except Exception as exc:  # pragma: no cover - network


### PR DESCRIPTION
## Summary
- update boolean search to use new field names
- handle skill strings and add type hints
- add tests for boolean search
- add ALL_STEP_KEYS constant
- auto fill session with canonical fields on extraction
- store uploaded file/URL information

## Testing
- `ruff check .`
- `black . --check`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850696edf508320aa8977f1613e7592