### PR TITLE
Fix file reading and boolean search

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Run tests (once they exist):
 pytest
 ```
 
+## Changelog
+
+- Enhanced file extraction to reset pointers for DOCX and TXT files
+- Improved Boolean search generation without city input
+
 ## Contributing
 
 - Use feature branches named `feat/<description>` and open PRs against `dev`.

--- a/functions/boolean_search.py
+++ b/functions/boolean_search.py
@@ -17,5 +17,6 @@ def generate_boolean_search(fields: Dict[str, Any]) -> str:
         return "# Nicht genug Daten für Boolean-String"
 
     skill_part = " OR ".join([f'"{skill}"' for skill in skills])
-    query = f'({skill_part}) AND "{job_title}" AND {city}'
+    city_part = f" AND {city}" if city else ""
+    query = f'({skill_part}) AND "{job_title}"{city_part}'
     return query

--- a/tests/test_boolean_search.py
+++ b/tests/test_boolean_search.py
@@ -21,6 +21,15 @@ def test_generate_boolean_search_with_string():
     assert result == '("Python" OR "SQL") AND "Data Scientist" AND Berlin'
 
 
+def test_generate_boolean_search_without_city():
+    fields = {
+        "must_have_skills": ["Python", "SQL"],
+        "job_title": "Data Scientist",
+    }
+    result = generate_boolean_search(fields)
+    assert result == '("Python" OR "SQL") AND "Data Scientist"'
+
+
 def test_generate_boolean_search_missing_data():
     fields = {"city": "Berlin"}
     result = generate_boolean_search(fields)

--- a/utils/utils_jobinfo.py
+++ b/utils/utils_jobinfo.py
@@ -27,6 +27,7 @@ def extract_text_from_pdf(file) -> str:
 def extract_text_from_docx(file) -> str:
     """Return text from a DOCX file including tables."""
 
+    file.seek(0)
     doc = docx.Document(file)
     lines = [para.text for para in doc.paragraphs]
 
@@ -61,6 +62,7 @@ def extract_text(file) -> str:
     if filetype == "docx":
         return extract_text_from_docx(file)
     if filetype == "txt":
+        file.seek(0)
         return file.read().decode("utf-8")
     raise ValueError("Unsupported file type")
 


### PR DESCRIPTION
## Summary
- ensure DOCX/TXT reading resets file pointer
- handle missing city in Boolean search generation
- test Boolean search without city
- document changes in README

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506d222850832097c65517034b24fe