### PR TITLE
feat: add ESCO-based skill and task suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ pytest
 - Enhanced file extraction to reset pointers for DOCX and TXT files
 - Improved Boolean search generation without city input
 - Wizard navigation now uses Next/Back buttons and two-column layout for large steps
+- Added ESCO-based suggestions for tasks and skills based on job title
 
 ## Contributing
 

--- a/tests/test_esco_client.py
+++ b/tests/test_esco_client.py
@@ -1,0 +1,29 @@
+from unittest.mock import Mock, patch
+
+from utils import esco_client
+
+
+def test_get_skills_for_job_title():
+    search_resp = {"_embedded": {"results": [{"uri": "http://example.com/occ"}]}}
+    related_resp = {
+        "_embedded": {"hasEssentialSkill": [{"title": "Skill A"}, {"title": "Skill B"}]}
+    }
+    with patch("utils.esco_client.requests.get") as mock_get:
+        mock_get.side_effect = [
+            Mock(status_code=200, json=lambda: search_resp),
+            Mock(status_code=200, json=lambda: related_resp),
+        ]
+        skills = esco_client.get_skills_for_job_title("Data Scientist")
+    assert skills == ["Skill A", "Skill B"]
+
+
+def test_get_tasks_for_job_title():
+    search_resp = {"_embedded": {"results": [{"uri": "http://example.com/occ"}]}}
+    occupation_resp = {"description": {"en": {"literal": "Task one. Task two. Other."}}}
+    with patch("utils.esco_client.requests.get") as mock_get:
+        mock_get.side_effect = [
+            Mock(status_code=200, json=lambda: search_resp),
+            Mock(status_code=200, json=lambda: occupation_resp),
+        ]
+        tasks = esco_client.get_tasks_for_job_title("Data Scientist")
+    assert tasks == ["Task one", "Task two", "Other"][:3]

--- a/utils/esco_client.py
+++ b/utils/esco_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 import requests
 
@@ -35,6 +35,76 @@ def search_skills(query: str, *, language: str = "en", limit: int = 10) -> List[
         data = response.json()
         results = data.get("_embedded", {}).get("results", [])
         return [r.get("title") for r in results if r.get("title")]
+    except Exception as exc:  # pragma: no cover - network
+        logger.warning("ESCO API request failed: %s", exc)
+        return []
+
+
+def _find_occupation_uri(job_title: str, *, language: str) -> Optional[str]:
+    """Return the ESCO URI for the given ``job_title`` if found."""
+
+    params: Dict[str, Union[str, int]] = {
+        "text": job_title,
+        "language": language,
+        "type": "occupation",
+        "limit": 1,
+        "full": "true",
+    }
+    response = requests.get(f"{BASE_URL}/search", params=params, timeout=10)
+    response.raise_for_status()
+    results = response.json().get("_embedded", {}).get("results", [])
+    if not results:
+        return None
+    return results[0].get("uri")
+
+
+def get_skills_for_job_title(
+    job_title: str, *, language: str = "en", limit: int = 10
+) -> List[str]:
+    """Return essential skills for ``job_title`` from ESCO."""
+
+    try:
+        occ_uri = _find_occupation_uri(job_title, language=language)
+        if not occ_uri:
+            return []
+        params: Dict[str, Union[str, int]] = {
+            "uri": occ_uri,
+            "relation": "hasEssentialSkill",
+            "language": language,
+            "limit": limit,
+            "full": "false",
+        }
+        resp = requests.get(f"{BASE_URL}/resource/related", params=params, timeout=10)
+        resp.raise_for_status()
+        skills = resp.json().get("_embedded", {}).get("hasEssentialSkill", [])
+        return [s.get("title") for s in skills if s.get("title")]
+    except Exception as exc:  # pragma: no cover - network
+        logger.warning("ESCO API request failed: %s", exc)
+        return []
+
+
+def get_tasks_for_job_title(
+    job_title: str, *, language: str = "en", limit: int = 10
+) -> List[str]:
+    """Return a list of typical tasks for ``job_title`` from ESCO."""
+
+    try:
+        occ_uri = _find_occupation_uri(job_title, language=language)
+        if not occ_uri:
+            return []
+        params: Dict[str, Union[str, int]] = {
+            "uri": occ_uri,
+            "language": language,
+        }
+        resp = requests.get(
+            f"{BASE_URL}/resource/occupation", params=params, timeout=10
+        )
+        resp.raise_for_status()
+        desc = resp.json().get("description", {}).get(language, {}).get("literal", "")
+        if not desc:
+            return []
+        sentences = [s.strip() for s in desc.split(".") if s.strip()]
+        return sentences[:limit]
     except Exception as exc:  # pragma: no cover - network
         logger.warning("ESCO API request failed: %s", exc)
         return []

--- a/wizard_steps.py
+++ b/wizard_steps.py
@@ -11,7 +11,11 @@ from utils.utils_jobinfo import (
     save_fields_to_session,
 )
 from utils.i18n import tr
-from utils.esco_client import search_skills
+from utils.esco_client import (
+    search_skills,
+    get_skills_for_job_title,
+    get_tasks_for_job_title,
+)
 import requests
 
 
@@ -210,6 +214,11 @@ def wizard_step_5_tasks() -> None:
     """Step 5: tasks and responsibilities."""
     lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
+    if fields.get("job_title") and not fields.get("task_list"):
+        tasks = get_tasks_for_job_title(fields["job_title"], language=lang, limit=5)
+        if tasks:
+            fields["task_list"] = "\n".join(tasks)
+            st.info(tr("Aufgaben von ESCO importiert", lang))
     st.header(tr("5. Aufgaben & Verantwortlichkeiten / Tasks & Responsibilities", lang))
     display_fields_summary()
     fields["task_list"] = st.text_area(
@@ -261,6 +270,11 @@ def wizard_step_6_skills() -> None:
     """Step 6: required skills."""
     lang = st.session_state.get("lang", "de")
     fields = st.session_state.get("job_fields", {})
+    if fields.get("job_title") and not fields.get("must_have_skills"):
+        skills = get_skills_for_job_title(fields["job_title"], language=lang, limit=5)
+        if skills:
+            fields["must_have_skills"] = ", ".join(skills)
+            st.info(tr("Skills von ESCO importiert", lang))
     st.header(tr("6. Skills & Kompetenzen / Skills & Competencies", lang))
     skill_query = st.text_input(
         tr("Skill bei ESCO suchen / Search skill in ESCO", lang)


### PR DESCRIPTION
## Summary
- auto-import skills/tasks from ESCO when a job title is provided
- expose new ESCO helper functions
- add tests for ESCO client
- document new feature in the changelog

## Testing
- `ruff check .`
- `black . --check`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508091e2ac83208ae4e1357bef5b64