### PR TITLE
fix: update streamlit rerun

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ pytest
 - Enhanced file extraction to reset pointers for DOCX and TXT files
 - Improved Boolean search generation without city input
 - Wizard navigation now uses Next/Back buttons and two-column layout for large steps
+- Replaced deprecated `st.experimental_rerun()` with `st.rerun()` for Streamlit 1.45+
 
 ## Contributing
 

--- a/app.py
+++ b/app.py
@@ -83,11 +83,11 @@ col_prev, col_next = st.columns(2)
 with col_prev:
     if st.button(tr("Zur\u00fcck / Back", lang), disabled=step_idx == 0):
         st.session_state["step_idx"] = max(0, step_idx - 1)
-        st.experimental_rerun()  # type: ignore[attr-defined]
+        st.rerun()
 with col_next:
     if st.button(tr("Weiter / Next", lang), disabled=step_idx == len(wizard_steps) - 1):
         st.session_state["step_idx"] = min(len(wizard_steps) - 1, step_idx + 1)
-        st.experimental_rerun()  # type: ignore[attr-defined]
+        st.rerun()
 
 # --- Utility-Optionen nach dem Wizard ------------------------------------
 st.markdown("---")


### PR DESCRIPTION
## Summary
- call `st.rerun()` for Streamlit 1.45+
- document updated rerun call in changelog

## Testing
- `ruff check .`
- `black . --check`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850810078208320b1c8d451fd1c6d20