### PR TITLE
feat: extend wizard with publication step

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ from wizard_steps import (
     wizard_step_6_skills,
     wizard_step_7_compensation,
     wizard_step_8_recruitment,
+    wizard_step_9_publication,
 )
 
 st.set_page_config(page_title="Vacalyser Wizard", layout="wide")
@@ -60,6 +61,7 @@ wizard_steps = [
     ("Skills / Kompetenzen", wizard_step_6_skills),
     ("Verg\u00fctung / Compensation", wizard_step_7_compensation),
     ("Recruiting-Prozess / Recruitment", wizard_step_8_recruitment),
+    ("Sprache & Veröffentlichung", wizard_step_9_publication),
 ]
 
 if "step_idx" not in st.session_state:

--- a/functions/processors.py
+++ b/functions/processors.py
@@ -1,0 +1,96 @@
+"""State update helpers used across wizard steps."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def update_task_list(state: dict[str, Any]) -> None:
+    """Populate ``task_list`` with generic tasks based on the role.
+
+    Parameters
+    ----------
+    state:
+        Session dictionary storing wizard fields.
+    """
+    if state.get("task_list"):
+        return
+    role = state.get("job_title") or state.get("role_description")
+    if not role:
+        return
+    tasks = [f"{role} task {i}" for i in range(1, 6)]
+    state["task_list"] = "\n".join(tasks)
+
+
+def update_must_have_skills(state: dict[str, Any]) -> None:
+    """Fill ``must_have_skills`` with placeholder skills."""
+    if state.get("must_have_skills"):
+        return
+    role = state.get("job_title") or "role"
+    skills = [f"{role} skill {i}" for i in range(1, 6)]
+    state["must_have_skills"] = ", ".join(skills)
+
+
+def update_nice_to_have_skills(state: dict[str, Any]) -> None:
+    """Suggest three complementary skills."""
+    if state.get("nice_to_have_skills"):
+        return
+    if not state.get("must_have_skills"):
+        return
+    extras = ["extra skill 1", "extra skill 2", "extra skill 3"]
+    state["nice_to_have_skills"] = ", ".join(extras)
+
+
+def update_salary_range(state: dict[str, Any]) -> None:
+    """Provide a simple salary range estimate if missing."""
+    current = str(state.get("salary_range", "")).strip().lower()
+    if current and current != "competitive":
+        return
+    state["salary_range"] = "45000 – 55000 EUR"
+
+
+def update_publication_channels(state: dict[str, Any]) -> None:
+    """Recommend publication channels for remote roles."""
+    policy = str(state.get("remote_work_policy", "")).lower()
+    if policy in {"hybrid", "full remote"}:
+        state["desired_publication_channels"] = "LinkedIn Remote Jobs; WeWorkRemotely"
+
+
+def update_bonus_scheme(state: dict[str, Any]) -> None:
+    """Add a bonus scheme suggestion for senior roles."""
+    if state.get("bonus_scheme"):
+        return
+    level = str(state.get("job_level", "")).lower()
+    if level in {"mid", "senior", "lead", "management"}:
+        state["bonus_scheme"] = "Eligible for an annual performance bonus."
+
+
+def update_commission_structure(state: dict[str, Any]) -> None:
+    """Suggest commission structure for sales-related titles."""
+    if state.get("commission_structure"):
+        return
+    title = str(state.get("job_title", "")).lower()
+    sales_terms = [
+        "sales",
+        "business development",
+        "account executive",
+        "account manager",
+    ]
+    if any(term in title for term in sales_terms):
+        state["commission_structure"] = "Commission based on sales performance."
+
+
+def update_translation_required(state: dict[str, Any]) -> None:
+    """Mark whether translation is needed based on language fields."""
+    if not state.get("language_requirements"):
+        return
+    required = {
+        lang.strip().lower()
+        for lang in state["language_requirements"].split(",")
+        if lang.strip()
+    }
+    ad_lang = str(state.get("language_of_ad", "English")).lower()
+    if ad_lang and ad_lang not in required:
+        state["translation_required"] = "Yes"
+    else:
+        state["translation_required"] = "No"

--- a/keys.py
+++ b/keys.py
@@ -94,6 +94,11 @@ STEP_KEYS: dict[int, list[str]] = {
         "recruitment_contact_phone",  # ⬚
         "application_instructions",  # ⬚
     ],
+    9: [  # Step 9: Language & Publication
+        "language_of_ad",  # ★
+        "translation_required",  # ◆
+        "desired_publication_channels",  # ⬚
+    ],
 }
 
 # Fields generated or used internally (not shown in UI steps)

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -1,0 +1,33 @@
+from functions.processors import (
+    update_bonus_scheme,
+    update_commission_structure,
+    update_publication_channels,
+    update_translation_required,
+)
+
+
+def test_update_bonus_scheme():
+    state = {"job_level": "Senior"}
+    update_bonus_scheme(state)
+    assert state["bonus_scheme"] == "Eligible for an annual performance bonus."
+
+
+def test_update_commission_structure():
+    state = {"job_title": "Sales Manager"}
+    update_commission_structure(state)
+    assert "Commission" in state["commission_structure"]
+
+
+def test_update_publication_channels():
+    state = {"remote_work_policy": "Hybrid"}
+    update_publication_channels(state)
+    assert state["desired_publication_channels"].startswith("LinkedIn")
+
+
+def test_update_translation_required():
+    state = {
+        "language_requirements": "English, German",
+        "language_of_ad": "English",
+    }
+    update_translation_required(state)
+    assert state["translation_required"] == "No"

--- a/wizard_steps.py
+++ b/wizard_steps.py
@@ -4,6 +4,17 @@ from __future__ import annotations
 
 import streamlit as st
 
+from functions.processors import (
+    update_bonus_scheme,
+    update_commission_structure,
+    update_must_have_skills,
+    update_nice_to_have_skills,
+    update_publication_channels,
+    update_salary_range,
+    update_task_list,
+    update_translation_required,
+)
+
 from utils.utils_jobinfo import (
     display_fields_summary,
     basic_field_extraction,
@@ -219,6 +230,7 @@ def wizard_step_5_tasks() -> None:
         if tasks:
             fields["task_list"] = "\n".join(tasks)
             st.info(tr("Aufgaben von ESCO importiert", lang))
+        update_task_list(fields)
     st.header(tr("5. Aufgaben & Verantwortlichkeiten / Tasks & Responsibilities", lang))
     display_fields_summary()
     fields["task_list"] = st.text_area(
@@ -275,6 +287,8 @@ def wizard_step_6_skills() -> None:
         if skills:
             fields["must_have_skills"] = ", ".join(skills)
             st.info(tr("Skills von ESCO importiert", lang))
+        update_must_have_skills(fields)
+    update_nice_to_have_skills(fields)
     st.header(tr("6. Skills & Kompetenzen / Skills & Competencies", lang))
     skill_query = st.text_input(
         tr("Skill bei ESCO suchen / Search skill in ESCO", lang)
@@ -358,6 +372,10 @@ def wizard_step_7_compensation() -> None:
     fields = st.session_state.get("job_fields", {})
     st.header(tr("7. Vergütung & Benefits / Compensation & Benefits", lang))
     display_fields_summary()
+    update_salary_range(fields)
+    update_bonus_scheme(fields)
+    update_commission_structure(fields)
+    update_publication_channels(fields)
     fields["salary_range"] = st.text_input(
         tr("Gehaltsrange / Salary Range *", lang), fields.get("salary_range", "")
     )
@@ -453,4 +471,28 @@ def wizard_step_8_recruitment() -> None:
             tr("Bewerbungsanweisungen / Application Instructions", lang),
             fields.get("application_instructions", ""),
         )
+    st.session_state["job_fields"] = fields
+
+
+def wizard_step_9_publication() -> None:
+    """Step 9: language and publication settings."""
+    lang = st.session_state.get("lang", "de")
+    fields = st.session_state.get("job_fields", {})
+    update_publication_channels(fields)
+    update_translation_required(fields)
+    st.header(tr("9. Sprache & Veröffentlichung / Language & Publication", lang))
+    display_fields_summary()
+    fields["language_of_ad"] = st.selectbox(
+        tr("Anzeigensprache / Ad Language", lang),
+        ["Deutsch", "English"],
+        index=0 if fields.get("language_of_ad", "Deutsch") == "Deutsch" else 1,
+    )
+    fields["desired_publication_channels"] = st.text_input(
+        tr("Publikationskanäle / Publication Channels", lang),
+        fields.get("desired_publication_channels", ""),
+    )
+    fields["translation_required"] = st.text_input(
+        tr("Übersetzung nötig? / Translation Required?", lang),
+        fields.get("translation_required", ""),
+    )
     st.session_state["job_fields"] = fields


### PR DESCRIPTION
## Summary
- add simple state processors for auto-suggestions
- insert new publication step in wizard
- wire processors into steps
- update step keys
- test helper functions

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68508518d6c083208816d831fa2200e7