### PR TITLE
fix: rerun outside column context

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,14 +93,17 @@ st.info(
 wizard_steps[step_idx][1]()
 
 col_prev, col_next = st.columns(2)
-with col_prev:
-    if st.button(tr("Zur\u00fcck / Back", lang), disabled=step_idx == 0):
-        st.session_state["step_idx"] = max(0, step_idx - 1)
-        st.rerun()
-with col_next:
-    if st.button(tr("Weiter / Next", lang), disabled=step_idx == len(wizard_steps) - 1):
-        st.session_state["step_idx"] = min(len(wizard_steps) - 1, step_idx + 1)
-        st.rerun()
+back_clicked = col_prev.button(tr("Zur\u00fcck / Back", lang), disabled=step_idx == 0)
+next_clicked = col_next.button(
+    tr("Weiter / Next", lang), disabled=step_idx == len(wizard_steps) - 1
+)
+
+if back_clicked:
+    st.session_state["step_idx"] = max(0, step_idx - 1)
+    st.rerun()
+if next_clicked:
+    st.session_state["step_idx"] = min(len(wizard_steps) - 1, step_idx + 1)
+    st.rerun()
 
 # --- Utility-Optionen nach dem Wizard ------------------------------------
 st.markdown("---")


### PR DESCRIPTION
## Summary
- prevent rerun exceptions in `app.py` by triggering button actions outside the column context

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685120a527d08320a5e0b5256c3385c8