### PR TITLE
fix: standardize org id env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ background from `images/AdobeStock_506577005.jpeg` with matching accent colours.
 Optional settings used in `utils/openai_client.py`:
 
 - `OPENAI_API_KEY`
-- `OPENAI_ORG`
+- `OPENAI_ORG_ID`
 
 Define them in your shell or inside `.streamlit/secrets.toml`.
 


### PR DESCRIPTION
## Summary
- use `OPENAI_ORG_ID` consistently in docs

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685122a18df48320929cbec91d1694a4