### PR TITLE
fix: close PDF documents properly

### DIFF
--- a/agents/file_agent.py
+++ b/agents/file_agent.py
@@ -21,5 +21,6 @@ def extract_text_from_pdf(uploaded_file: BinaryIO) -> str:
     """
 
     uploaded_file.seek(0)
-    doc = fitz.open(stream=uploaded_file.read(), filetype="pdf")
-    return "\n".join(page.get_text() for page in doc)
+    with fitz.open(stream=uploaded_file.read(), filetype="pdf") as doc:
+        text = "\n".join(page.get_text() for page in doc)
+    return text

--- a/tests/test_file_agent.py
+++ b/tests/test_file_agent.py
@@ -1,0 +1,39 @@
+from io import BytesIO
+
+from agents.file_agent import extract_text_from_pdf
+
+
+class DummyPage:
+    def get_text(self) -> str:
+        return "dummy"
+
+
+class DummyDoc:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def __iter__(self):
+        return iter([DummyPage()])
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+def test_extract_text_from_pdf_closes_doc(monkeypatch):
+    dummy_doc = DummyDoc()
+
+    def fake_open(*args, **kwargs):
+        return dummy_doc
+
+    import agents.file_agent as file_agent
+
+    monkeypatch.setattr(file_agent.fitz, "open", fake_open)
+    text = extract_text_from_pdf(BytesIO(b"dummy"))
+    assert text == "dummy"
+    assert dummy_doc.closed is True


### PR DESCRIPTION
## Summary
- ensure PDF extraction closes the fitz document with a context manager
- add regression test to check document closure

## Testing
- `ruff check agents/file_agent.py tests/test_file_agent.py`
- `mypy agents/file_agent.py tests/test_file_agent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685122aebeac8320a8acbf922cd34be8