### PR TITLE
fix: date input default handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ pytest
 - Improved Boolean search generation without city input
 - Wizard navigation now uses Next/Back buttons and two-column layout for large steps
 - Replaced deprecated `st.experimental_rerun()` with `st.rerun()` for Streamlit 1.45+
+- Default start date to today's date when none stored
 
 
 ## Contributing

--- a/tests/test_wizard_steps.py
+++ b/tests/test_wizard_steps.py
@@ -1,0 +1,27 @@
+import datetime
+from contextlib import nullcontext
+from unittest.mock import patch
+
+import streamlit as st
+
+from wizard_steps import wizard_step_4_role
+
+
+def test_wizard_step_4_role_defaults_today():
+    st.session_state.clear()
+    st.session_state["lang"] = "de"
+    st.session_state["job_fields"] = {}
+
+    today = datetime.date.today()
+    with (
+        patch("wizard_steps.st.header"),
+        patch("wizard_steps.display_fields_summary"),
+        patch("wizard_steps.st.selectbox", return_value=""),
+        patch("wizard_steps.st.text_area", return_value=""),
+        patch("wizard_steps.st.text_input", return_value=""),
+        patch("wizard_steps.st.columns", return_value=(nullcontext(), nullcontext())),
+        patch("wizard_steps.st.expander", return_value=nullcontext()),
+        patch("wizard_steps.st.date_input", return_value=today) as mock_date,
+    ):
+        wizard_step_4_role()
+        assert mock_date.call_args.args[1] == today

--- a/wizard_steps.py
+++ b/wizard_steps.py
@@ -189,7 +189,9 @@ def wizard_step_4_role() -> None:
             try:
                 start_value = datetime.datetime.fromisoformat(start_value).date()
             except ValueError:
-                start_value = None
+                start_value = datetime.date.today()
+        elif not isinstance(start_value, datetime.date):
+            start_value = datetime.date.today()
         fields["date_of_employment_start"] = st.date_input(
             tr("Startdatum / Start Date", lang),
             start_value,


### PR DESCRIPTION
## Summary
- default employment start date to today when stored value is missing or invalid
- cover start date behaviour with a new test
- document the fix in the changelog

## Testing
- `ruff check .`
- `black . --check`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851229954b08320a7e1d8f732f1f911